### PR TITLE
Transforms to bringup

### DIFF
--- a/launch/base.launch
+++ b/launch/base.launch
@@ -13,14 +13,12 @@
         <arg name="debug" value="false"/>
     </include>
 
-    <param name="robot_description" command="$(find xacro)/xacro $(find scuttle_description)/urdf/scuttle.xacro" />
-
-    <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf" args="-urdf -model scuttle -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
-
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
-
     <include file="$(find scuttle_bringup)/launch/scuttle_bringup.launch">
         <arg name="is_physical" value="false"/>
     </include>
+
+    <!--
+        scuttle_bringup loads the robot model into the 'robot_description' parameter on the parameter server
+    -->
+    <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf" args="-urdf -model scuttle -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>scuttle_gazebo</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>Gazebo simulation package for the SCUTTLE</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>ApacheV2</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
@@ -58,8 +58,7 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <exec_depend>gazebo</exec_depend>
-  <exec_depend>scuttle_description</exec_depend>
-
+  <exec_depend>scuttle_bringup</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
This PR is part of the addition of `scuttle_model` (see scuttlerobot/scuttle_model#2). This PR moves the `joint_state_publisher` and the `robot_state_publisher` nodes from the `base.launch` file to the `scuttlerobot/scuttle_bringup` repository so that these nodes are provided both when running with Gazebo and on a physical SCUTTLE robot.

The link order of the packages is:

scuttle_gazebo -> scuttle_bringup -> joint_state_publisher
                                                        -> robot_state_publisher
                                                        -> scuttle_model (scuttle.xacro)
                                                        -> scuttle_driver
                                                        -> scuttle_navigation
                                                        -> twist_mux (http://wiki.ros.org/twist_mux)
                                                        -> scuttle_model                                   -> scuttle_description
